### PR TITLE
Business service dereferenced when deleting Stakeholder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,25 +56,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.github.konveyor.tackle-commons-rest</groupId>
-      <artifactId>commons-rest-test</artifactId>
-      <version>main-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-agroal</artifactId>
     </dependency>
     <dependency>
@@ -84,19 +65,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-rest-data-panache</artifactId>
-    </dependency>
-    <!--
-      wrong to depend on "*-deployment" in an application but done
-      for using io.quarkus.rest.data.panache.deployment.utils.ResourceName in ListFilteredResource.
-      If such method will be rewritten/replaced, the dependency can be removed.
-    -->
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-data-panache-deployment</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -114,41 +82,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-flyway</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.slf4j</groupId>
-      <artifactId>slf4j-jboss-logmanager</artifactId>
-      <scope>test</scope>
-    </dependency>
-<!--    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>-->
-    <!-- todo remove Hibernate Envers? -->
-<!--    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-hibernate-envers</artifactId>
-    </dependency>-->
     <!-- todo remove Hibernate Validator? -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
-<!--    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-kubernetes</artifactId>
-    </dependency>-->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health</artifactId>
@@ -168,6 +106,39 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-keycloak-authorization</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.konveyor.tackle-commons-rest</groupId>
+      <artifactId>commons-rest-test</artifactId>
+      <version>main-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.slf4j</groupId>
+      <artifactId>slf4j-jboss-logmanager</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/io/tackle/controls/entities/BusinessService.java
+++ b/src/main/java/io/tackle/controls/entities/BusinessService.java
@@ -1,6 +1,5 @@
 package io.tackle.controls.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.tackle.commons.annotations.Filterable;
 import io.tackle.commons.entities.AbstractEntity;
 import org.hibernate.annotations.ResultCheckStyle;
@@ -23,7 +22,6 @@ public class BusinessService extends AbstractEntity {
     @Filterable
     public String description;
     @ManyToOne
-    @JsonIgnoreProperties({"jobFunction", "email"})
     @Filterable(filterName = "owner.displayName")
     public Stakeholder owner;
 }

--- a/src/main/java/io/tackle/controls/entities/BusinessService.java
+++ b/src/main/java/io/tackle/controls/entities/BusinessService.java
@@ -16,7 +16,6 @@ import javax.persistence.Table;
 @SQLDelete(sql = "UPDATE business_service SET deleted = true WHERE id = ?", check = ResultCheckStyle.COUNT)
 @Where(clause = "deleted = false")
 public class BusinessService extends AbstractEntity {
-    @Column(unique=true)
     @Filterable
     public String name;
     @Filterable

--- a/src/main/java/io/tackle/controls/entities/Stakeholder.java
+++ b/src/main/java/io/tackle/controls/entities/Stakeholder.java
@@ -1,5 +1,6 @@
 package io.tackle.controls.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import io.tackle.commons.entities.AbstractEntity;
 import io.tackle.commons.annotations.Filterable;
 import org.hibernate.annotations.ResultCheckStyle;
@@ -7,7 +8,12 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import javax.persistence.PreRemove;
 import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "stakeholder")
@@ -20,4 +26,12 @@ public class Stakeholder extends AbstractEntity {
     public String jobFunction;
     @Filterable
     public String email;
+    @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY)
+    @JsonBackReference
+    public List<BusinessService> businessServices = new ArrayList<>();
+
+    @PreRemove
+    private void preRemove() {
+        businessServices.forEach(businessService -> businessService.owner = null);
+    }
 }

--- a/src/main/resources/db/migration/V20210302__alter_business-service.sql
+++ b/src/main/resources/db/migration/V20210302__alter_business-service.sql
@@ -1,0 +1,5 @@
+alter table if exists business_service
+    add constraint UK_btcp3rc4skxn0oyxbbnok68do unique (name),
+    add constraint FK64f0d7vxcp60lyjlttb7dqk3t
+    foreign key (owner_id)
+    references stakeholder;

--- a/src/main/resources/db/migration/V20210302__alter_business-service.sql
+++ b/src/main/resources/db/migration/V20210302__alter_business-service.sql
@@ -1,5 +1,4 @@
 alter table if exists business_service
-    add constraint UK_btcp3rc4skxn0oyxbbnok68do unique (name),
     add constraint FK64f0d7vxcp60lyjlttb7dqk3t
     foreign key (owner_id)
     references stakeholder;

--- a/src/test/java/io/tackle/controls/issues/Issue9Test.java
+++ b/src/test/java/io/tackle/controls/issues/Issue9Test.java
@@ -1,0 +1,95 @@
+package io.tackle.controls.issues;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.tackle.commons.testcontainers.KeycloakTestResource;
+import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
+import io.tackle.commons.tests.SecuredResourceTest;
+import io.tackle.controls.entities.BusinessService;
+import io.tackle.controls.entities.Stakeholder;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// https://github.com/konveyor/tackle-controls/issues/9
+@QuarkusTest
+@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
+        initArgs = {
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "controls_db"),
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "controls"),
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "controls")
+        }
+)
+@QuarkusTestResource(value = KeycloakTestResource.class,
+        initArgs = {
+                @ResourceArg(name = KeycloakTestResource.IMPORT_REALM_JSON_PATH, value = "keycloak/quarkus-realm.json"),
+                @ResourceArg(name = KeycloakTestResource.REALM_NAME, value = "quarkus")
+        }
+)
+public class Issue9Test extends SecuredResourceTest {
+
+    @Test
+    public void testIssue9() {
+        Stakeholder owner = new Stakeholder();
+        owner.displayName = "Owner";
+        Response ownerResponse = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(owner)
+                .when().post("/stakeholder")
+                .then()
+                .log().all()
+                .statusCode(201).extract().response();
+        Long ownerId = Long.valueOf(ownerResponse.path("id").toString());
+
+        BusinessService businessService = new BusinessService();
+        businessService.name = "Business Service";
+        businessService.owner = ownerResponse.as(Stakeholder.class);
+        Response businessServiceResponse = given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(businessService)
+                .when()
+                .log().all()
+                .post("/business-service")
+                .then()
+                .log().all()
+                .statusCode(201).extract().response();
+        Long businessServiceId = Long.valueOf(businessServiceResponse.path("id").toString());
+
+        given()
+                .accept("application/json")
+                .queryParam("name", "business")
+                .when().get("/business-service")
+                .then()
+                .log().all()
+                .statusCode(200)
+                .body("name[0]", is("Business Service"),
+                        "owner[0].displayName", is("Owner"),
+                        "id[0]", is(businessServiceId.intValue()),
+                        "size()", is(1));
+
+        given()
+            .pathParam("id", ownerId)
+            .when().delete("/stakeholder/{id}")
+            .then().statusCode(204);
+
+        given()
+            .accept("application/json")
+            .queryParam("name", "business")
+            .when().get("/business-service")
+            .then()
+            .log().all()
+            .statusCode(200)
+            .body("name[0]", is("Business Service"),
+                    "owner[0]", is(emptyOrNullString()),
+                    "id[0]", is(businessServiceId.intValue()),
+                    "size()", is(1));
+    }
+}


### PR DESCRIPTION
resolve #9 

With soft delete in place, leveraging something like `ON DELETE SET NULL` on the FK for BusinessService entity is not an option because Stakeholder entries are never deleted (i.e. with soft delete, deleting means update `deleted` field to `true`).
So the method
```java
@PreRemove
private void preRemove() {
    businessServices.forEach(businessService -> businessService.owner = null);
}
```
has been introduce to de-reference the Business Service from the to-be-deleted Stakeholder.

For reproducing the issue (and I think we should consider requesting this more in the future) I create a test case in a `issues` folder with the tests folder.