### PR TITLE
Fix Flyway migration scripts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,3 +64,22 @@ jobs:
         with:
           file: ./target/site/jacoco-ut/jacoco.xml
           name: codecov
+
+  flyway-migration-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -U -B test -Dquarkus.test.profile.tags=flyway --file pom.xml

--- a/src/main/resources/db/migration/V20210309.4__insert_tag.sql
+++ b/src/main/resources/db/migration/V20210309.4__insert_tag.sql
@@ -59,7 +59,7 @@ SELECT nextval('hibernate_sequence'), 'COBOL', id, '<shipped-data>', CURRENT_TIM
 FROM tag_type
 WHERE name = 'Language';
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
-SELECT nextval('hibernate_sequence'), 'Java EE', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+SELECT nextval('hibernate_sequence'), 'Java', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
 FROM tag_type
 WHERE name = 'Language';
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
@@ -75,7 +75,7 @@ SELECT nextval('hibernate_sequence'), 'RHEL 8', id, '<shipped-data>', CURRENT_TI
 FROM tag_type
 WHERE name = 'Operating System';
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
-SELECT nextval('hibernate_sequence'), 'Windows Server id16', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+SELECT nextval('hibernate_sequence'), 'Windows Server 2016', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
 FROM tag_type
 WHERE name = 'Operating System';
 INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)

--- a/src/main/resources/db/migration/V20210309.4__insert_tag.sql
+++ b/src/main/resources/db/migration/V20210309.4__insert_tag.sql
@@ -1,28 +1,112 @@
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'COTS', 18, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'In house', 18, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'SaaS', 18, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Boston (USA)', 19, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'London (UK)', 19, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Paris (FR)', 19, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Sydney (AU)', 19, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'DB2', 20, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'MongoDB', 20, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Oracle', 20, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Postgresql', 20, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'SQL Server', 20, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'C# ASP .Net', 21, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'C++', 21, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'COBOL', 21, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Java EE', 21, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Javascript', 21, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Python', 21, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'RHEL 8', 22, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Windows Server 2016', 22, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Z/OS', 22, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'EAP', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'JWS', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Quarkus', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Spring Boot', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'Tomcat', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'WebLogic', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
-INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted) VALUES (nextval('hibernate_sequence'), 'WebSphere', 23, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false);
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'COTS', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Application Type';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'In house', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Application Type';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'SaaS', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Application Type';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Boston (USA)', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Data Center';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'London (UK)', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Data Center';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Paris (FR)', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Data Center';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Sydney (AU)', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Data Center';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'DB2', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Database';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'MongoDB', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Database';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Oracle', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Database';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Postgresql', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Database';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'SQL Server', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Database';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'C# ASP .Net', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Language';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'C++', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Language';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'COBOL', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Language';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Java EE', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Language';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Javascript', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Language';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Python', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Language';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'RHEL 8', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Operating System';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Windows Server id16', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Operating System';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Z/OS', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Operating System';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'EAP', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'JWS', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Quarkus', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Spring Boot', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'Tomcat', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'WebLogic', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';
+INSERT INTO tag (id, name, tagType_id, createUser, createTime, updateUser, updateTime, deleted)
+SELECT nextval('hibernate_sequence'), 'WebSphere', id, '<shipped-data>', CURRENT_TIMESTAMP, '<shipped-data>', CURRENT_TIMESTAMP, false
+FROM tag_type
+WHERE name = 'Runtime';

--- a/src/test/java/io/tackle/controls/flyway/FlywayMigrationProfile.java
+++ b/src/test/java/io/tackle/controls/flyway/FlywayMigrationProfile.java
@@ -1,0 +1,47 @@
+package io.tackle.controls.flyway;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class FlywayMigrationProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Collections.singletonMap("quarkus.oidc.enabled","false");
+    }
+
+    @Override
+    public Set<Class<?>> getEnabledAlternatives() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getConfigProfile() {
+        return "flyway";
+    }
+
+    @Override
+    public List<TestResourceEntry> testResources() {
+        Map<String, String> args = new HashMap<>(3);
+        args.put(PostgreSQLDatabaseTestResource.DB_NAME,"controls_db");
+        args.put(PostgreSQLDatabaseTestResource.USER,"controls");
+        args.put(PostgreSQLDatabaseTestResource.PASSWORD,"controls");
+        return Collections.singletonList(new TestResourceEntry(PostgreSQLDatabaseTestResource.class, args));
+    }
+
+    @Override
+    public Set<String> tags() {
+        return Collections.singleton("flyway");
+    }
+    
+    @Override
+    public boolean disableGlobalTestResources() {
+        return true;
+    }
+}

--- a/src/test/java/io/tackle/controls/flyway/FlywayMigrationTest.java
+++ b/src/test/java/io/tackle/controls/flyway/FlywayMigrationTest.java
@@ -1,0 +1,34 @@
+package io.tackle.controls.flyway;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@TestProfile(FlywayMigrationProfile.class)
+public class FlywayMigrationTest {
+    
+    @Inject
+    Flyway flyway;
+    
+    @Test
+    public void testMigration() {
+        // check the number of migrations applied equals the number of files in resources/db/migration folder
+        assertEquals(12, flyway.info().applied().length);
+        // check the current migration version is the one from the last file in resources/db/migration folder
+        assertEquals("20210309.4", flyway.info().current().getVersion().toString());
+        // just a basic test to double check the application started
+        // to prove the flyway scripts ran successfully during startup
+        given()
+            .accept("application/json")
+            .when().get("/q/health/")
+            .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/tackle/controls/resources/issues/Issue9Test.java
+++ b/src/test/java/io/tackle/controls/resources/issues/Issue9Test.java
@@ -1,4 +1,4 @@
-package io.tackle.controls.issues;
+package io.tackle.controls.resources.issues;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.common.ResourceArg;


### PR DESCRIPTION
resolve https://github.com/konveyor/tackle-ui/issues/23

- added `FlywayMigrationProfile` in order to be able to not run with default `test` profile to exclude the `db/test-data` folder from the flyway migration execution to simulate the prod flyway migration
- moved `issues` test folder within `resources` following the Quarkus recommended practice `In order to reduce the amount of times Quarkus needs to restart it is recommended that you place all tests that need a specific profile into their own package` (ref [Testing Different Profiles](https://quarkus.io/guides/getting-started-testing#testing_different_profiles))
- added `flyway-migration-test` GH workflow for PRs to fail-fast in case of issues with Flyway migration

Commit 61b1d79 only introduce the test to prove it breaks with current `main` branch so that 54fd203 will prove to be a fix for the issue.