### PR TITLE
Downgrade to Quarkus 1.12.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.platform.version>1.13.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>1.12.2.Final</quarkus.platform.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
 <!--    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>-->
 <!--    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>-->
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus-plugin.version>1.13.0.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>1.12.2.Final</quarkus-plugin.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <testcontainers.version>1.15.2</testcontainers.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>


### PR DESCRIPTION
Using Quarkus `1.13.0.Final` the endpoints failed with a `401 Unauthorized` error when deployed in an OCP instance.
Since the tests didn't capture this fail, the version is downgraded waiting for a way to reproduce the issue.