### PR TITLE
Stakeholder update management for referenced entities (Job Function, Stakeholder groups)

### DIFF
--- a/src/main/java/io/tackle/controls/entities/Stakeholder.java
+++ b/src/main/java/io/tackle/controls/entities/Stakeholder.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Entity
@@ -63,5 +64,18 @@ public class Stakeholder extends AbstractEntity {
             if (stakeholderGroupFromDb != null) stakeholderGroupFromDb.stakeholders.add(this);
             else iter.remove();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Stakeholder)) return false;
+        Stakeholder stakeholder = (Stakeholder) o;
+        return Objects.equals(id, stakeholder.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/io/tackle/controls/entities/StakeholderGroup.java
+++ b/src/main/java/io/tackle/controls/entities/StakeholderGroup.java
@@ -14,6 +14,7 @@ import javax.persistence.ManyToMany;
 import javax.persistence.PreRemove;
 import javax.persistence.Table;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 @Entity
@@ -38,5 +39,18 @@ public class StakeholderGroup extends AbstractEntity {
     @PreRemove
     private void preRemove() {
         stakeholders.forEach(stakeholder -> stakeholder.stakeholderGroups.remove(this));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StakeholderGroup)) return false;
+        StakeholderGroup group = (StakeholderGroup) o;
+        return Objects.equals(id, group.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/io/tackle/controls/resources/StakeholderResource.java
+++ b/src/main/java/io/tackle/controls/resources/StakeholderResource.java
@@ -1,11 +1,11 @@
 package io.tackle.controls.resources;
 
-import io.tackle.controls.entities.Stakeholder;
 import io.quarkus.hibernate.orm.rest.data.panache.PanacheEntityResource;
 import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.quarkus.rest.data.panache.MethodProperties;
 import io.quarkus.rest.data.panache.ResourceProperties;
+import io.tackle.controls.entities.Stakeholder;
 
 import java.util.List;
 
@@ -13,4 +13,7 @@ import java.util.List;
 public interface StakeholderResource extends PanacheEntityResource<Stakeholder, Long> {
     @MethodProperties(exposed = false)
     List<Stakeholder> list(Page page, Sort sort);
+
+    @MethodProperties(exposed = false)
+    Stakeholder update(Long id, Stakeholder stakeholder);
 }

--- a/src/main/java/io/tackle/controls/resources/StakeholderUpdateResource.java
+++ b/src/main/java/io/tackle/controls/resources/StakeholderUpdateResource.java
@@ -1,0 +1,119 @@
+package io.tackle.controls.resources;
+
+import io.tackle.controls.entities.Stakeholder;
+import io.tackle.controls.entities.StakeholderGroup;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.links.LinkResource;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static javax.ws.rs.core.Response.Status.NO_CONTENT;
+
+@Path("stakeholder")
+public class StakeholderUpdateResource {
+
+    @Inject
+    Logger logger;
+/*
+    These are the synthetic methods create from Quarkus REST Panache.
+    They manage the 'PUT' verb both for creating and updating Stakeholder.
+    In this implementation I've removed the creation part to let it be done using the 'POST' verb.
+    
+    @Path("/{id}")
+    @Transactional
+    @PUT
+    @Consumes({"application/json"})
+    @Produces({"application/json"})
+    @LinkResource(
+            entityClassName = "io.tackle.controls.entities.Stakeholder",
+            rel = "update"
+    )
+    public Response update(@PathParam("id") Long var1, Stakeholder var2) {
+        StakeholderResourceImpl_cdf008bf94ad72ddbf067ca9cadc332df33146e6 var3 = this.resource;
+        if (var3.get(var1) == null) {
+            Object var4 = var3.update(var1, var2);
+            String var5 = (new ResourceLinksProvider()).getSelfLink(var4);
+            if (var5 != null) {
+                URI var7 = URI.create(var5);
+                Response.ResponseBuilder var6 = Response.status(201);
+                var6.entity(var4);
+                var6.location(var7);
+                return var6.build();
+            } else {
+                throw (Throwable)(new RuntimeException("Could not extract a new entity URL"));
+            }
+        } else {
+            var3.update(var1, var2);
+            return Response.status(204).build();
+        }
+    }
+
+    @Path("/{id}")
+    @Transactional
+    @PUT
+    @Consumes({"application/json"})
+    @Produces({"application/hal+json"})
+    public Response updateHal(@PathParam("id") Long var1, Stakeholder var2) {
+        StakeholderResourceImpl_cdf008bf94ad72ddbf067ca9cadc332df33146e6 var3 = this.resource;
+        if (var3.get(var1) == null) {
+            Object var4 = var3.update(var1, var2);
+            HalEntityWrapper var6 = new HalEntityWrapper(var4);
+            String var5 = (new ResourceLinksProvider()).getSelfLink(var4);
+            if (var5 != null) {
+                URI var8 = URI.create(var5);
+                Response.ResponseBuilder var7 = Response.status(201);
+                var7.entity(var6);
+                var7.location(var8);
+                return var7.build();
+            } else {
+                throw (Throwable)(new RuntimeException("Could not extract a new entity URL"));
+            }
+        } else {
+            var3.update(var1, var2);
+            return Response.status(204).build();
+        }
+    }
+*/
+
+    @Path("/{id}")
+    @Transactional
+    @PUT
+    @Consumes({"application/json"})
+    @Produces({"application/json", "application/hal+json"})
+    @LinkResource(
+            entityClassName = "io.tackle.controls.entities.Stakeholder",
+            rel = "update"
+    )
+    public Response update(@PathParam("id") Long id, Stakeholder stakeholder) {
+        stakeholder.id = id;
+        // update the many-to-many StakeholderGroup relation from the Stakeholder side, the non-owning one
+        logger.debugf("Load list of current Stakeholder groups for %s", stakeholder);
+        List<StakeholderGroup> currentStakeholderGroups = StakeholderGroup.list("SELECT table FROM StakeholderGroup table JOIN table.stakeholders stakeholder WHERE stakeholder.id = ?1", id);
+        logger.debugf("Loaded %d Stakeholder groups for %s from DB", currentStakeholderGroups.size(), stakeholder);
+        currentStakeholderGroups.forEach(currentStakeholderGroup -> {
+            logger.debugf("Is %s still a stakeholder group for %s in the request?", currentStakeholderGroup, stakeholder);
+            if (!stakeholder.stakeholderGroups.contains(currentStakeholderGroup)) {
+                logger.debugf("No hence remove %s from stakeholders for %s", stakeholder, currentStakeholderGroup);
+                currentStakeholderGroup.stakeholders.remove(stakeholder);
+                logger.debugf("%s removed", stakeholder);
+            }
+            else {
+                logger.debugf("Yes, no need to remove %s from %s", stakeholder, currentStakeholderGroup);
+            }
+        });
+
+        // once https://github.com/quarkusio/quarkus/issues/15961 will be fixed, this should become useless
+        Stakeholder.update("jobFunction = ?1 where id = ?2", stakeholder.jobFunction, id);
+
+        stakeholder.getEntityManager().merge(stakeholder);
+        return Response.status(NO_CONTENT).build();
+    }
+}

--- a/src/test/java/io/tackle/controls/entities/StakeholderGroupTest.java
+++ b/src/test/java/io/tackle/controls/entities/StakeholderGroupTest.java
@@ -1,0 +1,49 @@
+package io.tackle.controls.entities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class StakeholderGroupTest {
+    @Test
+    public void testEquals() {
+        StakeholderGroup x = new StakeholderGroup();
+        x.id = 0L;
+        StakeholderGroup y = new StakeholderGroup();
+        y.id = 0L;
+        StakeholderGroup z = new StakeholderGroup();
+        z.id = 0L;
+        // Reflexive
+        assertEquals(x, x);
+        // Symmetric
+        assertEquals(x.equals(y), y.equals(x));
+        // Transitive
+        assertEquals(x.equals(y) && y.equals(z), x.equals(z));
+        // Consistent
+        assertEquals(x, y);
+        y.name = "y";
+        y.description = "y";
+        assertEquals(x, y);
+        // Non-nullity
+        assertFalse(x.equals(null));
+
+        assertNotEquals( "test", z);
+    }
+
+    @Test
+    public void testHashCode() {
+        StakeholderGroup x = new StakeholderGroup();
+        x.id = 0L;
+        int initial = x.hashCode();
+        x.name = "x";
+        x.description = "x";
+        assertEquals(initial, x.hashCode());
+        StakeholderGroup y = new StakeholderGroup();
+        y.id = 0L;
+        assertEquals(x, y);
+        assertEquals(x.hashCode(), y.hashCode());
+    }
+
+}

--- a/src/test/java/io/tackle/controls/entities/StakeholderTest.java
+++ b/src/test/java/io/tackle/controls/entities/StakeholderTest.java
@@ -1,0 +1,49 @@
+package io.tackle.controls.entities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class StakeholderTest {
+    @Test
+    public void testEquals() {
+        Stakeholder x = new Stakeholder();
+        x.id = 0L;
+        Stakeholder y = new Stakeholder();
+        y.id = 0L;
+        Stakeholder z = new Stakeholder();
+        z.id = 0L;
+        // Reflexive
+        assertEquals(x, x);
+        // Symmetric
+        assertEquals(x.equals(y), y.equals(x));
+        // Transitive
+        assertEquals(x.equals(y) && y.equals(z), x.equals(z));
+        // Consistent
+        assertEquals(x, y);
+        y.email = "y";
+        y.displayName = "y";
+        assertEquals(x, y);
+        // Non-nullity
+        assertFalse(x.equals(null));
+
+        assertNotEquals( "test", z);
+    }
+
+    @Test
+    public void testHashCode() {
+        Stakeholder x = new Stakeholder();
+        x.id = 0L;
+        int initial = x.hashCode();
+        x.email = "x";
+        x.displayName = "x";
+        assertEquals(initial, x.hashCode());
+        Stakeholder y = new Stakeholder();
+        y.id = 0L;
+        assertEquals(x, y);
+        assertEquals(x.hashCode(), y.hashCode());
+    }
+
+}

--- a/src/test/java/io/tackle/controls/resources/issues/Issues64_66Test.java
+++ b/src/test/java/io/tackle/controls/resources/issues/Issues64_66Test.java
@@ -1,0 +1,201 @@
+package io.tackle.controls.resources.issues;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.ResourceArg;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.tackle.commons.testcontainers.KeycloakTestResource;
+import io.tackle.commons.testcontainers.PostgreSQLDatabaseTestResource;
+import io.tackle.commons.tests.SecuredResourceTest;
+import io.tackle.controls.entities.BusinessService;
+import io.tackle.controls.entities.JobFunction;
+import io.tackle.controls.entities.Stakeholder;
+import io.tackle.controls.entities.StakeholderGroup;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@QuarkusTestResource(value = PostgreSQLDatabaseTestResource.class,
+        initArgs = {
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.DB_NAME, value = "controls_db"),
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.USER, value = "controls"),
+                @ResourceArg(name = PostgreSQLDatabaseTestResource.PASSWORD, value = "controls")
+        }
+)
+@QuarkusTestResource(value = KeycloakTestResource.class,
+        initArgs = {
+                @ResourceArg(name = KeycloakTestResource.IMPORT_REALM_JSON_PATH, value = "keycloak/quarkus-realm.json"),
+                @ResourceArg(name = KeycloakTestResource.REALM_NAME, value = "quarkus")
+        }
+)
+public class Issues64_66Test extends SecuredResourceTest {
+
+    @Test
+    public void test() {
+        // create a new job function
+        final String role = "chef";
+        final JobFunction chef = new JobFunction();
+        chef.role = role;
+        chef.id = Long.valueOf(given()
+                .contentType(ContentType.JSON)
+                .body(chef)
+                .when()
+                .post("/job-function")
+                .then()
+                .statusCode(is(201))
+                .extract()
+                .path("id")
+                .toString());
+
+        // use the already existing stakeholder groups
+        final StakeholderGroup managers = new StakeholderGroup();
+        managers.id = 52L;
+        final StakeholderGroup engineers = new StakeholderGroup();
+        engineers.id = 53L;
+        final StakeholderGroup marketing = new StakeholderGroup();
+        marketing.id = 54L;
+
+        // create a stakeholder with a job function
+        final String stakeholderDisplayName = "Display Name";
+        final Stakeholder stakeholder = new Stakeholder();
+        stakeholder.displayName = stakeholderDisplayName;
+        stakeholder.email = "x@y.z";
+        // just inserted job function use case
+        stakeholder.jobFunction = chef;
+        stakeholder.stakeholderGroups = Set.of(managers, engineers, marketing);
+        stakeholder.id = Long.valueOf(given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(stakeholder)
+                .when()
+                .post("/stakeholder")
+                .then()
+                .statusCode(is(201))
+                .extract()
+                .path("id")
+                .toString());
+
+        // check the stakeholder has the job function
+        // and the three stakeholder groups in the response
+        given()
+                .accept("application/hal+json")
+                .queryParam("displayName", stakeholderDisplayName)
+                .body(stakeholder)
+                .when()
+                .get("/stakeholder")
+                .then()
+                .statusCode(is(200))
+                .body("_embedded.stakeholder[0].jobFunction.role", is(role),
+                        "_embedded.stakeholder[0].stakeholderGroups.size()", is(3));
+        
+        // create a business service with owner the stakeholder just created 
+        final String businessServiceName = "it works";
+        final BusinessService businessService = new BusinessService();
+        businessService.name = businessServiceName;
+        businessService.description = "yes, it works";
+        businessService.owner = stakeholder;
+        businessService.id = Long.valueOf(given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .body(businessService)
+                .when()
+                .post("/business-service")
+                .then()
+                .statusCode(is(201))
+                .extract()
+                .path("id")
+                .toString());
+
+        // check the business service has the owner in the response
+        given()
+                .accept(ContentType.JSON)
+                .queryParam("name", businessServiceName)
+                .body(stakeholder)
+                .when()
+                .get("/business-service")
+                .then()
+                .statusCode(is(200))
+                .body("[0].owner.displayName", is(stakeholderDisplayName));
+
+        // remove the owner from the business service
+        businessService.owner = null;
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .pathParam("id", businessService.id)
+                .body(businessService)
+                .when()
+                .put("/business-service/{id}")
+                .then()
+                .statusCode(is(204));
+
+        // check the business service has NO owner
+        given()
+                .accept(ContentType.JSON)
+                .queryParam("name", businessServiceName)
+                .body(stakeholder)
+                .when()
+                .get("/business-service")
+                .then()
+                .statusCode(is(200))
+                .body("[0].owner.displayName", is(emptyOrNullString()),
+                "[0].owner", is(emptyOrNullString()));
+
+        // Issue#64: remove the job function from the stakeholder
+        stakeholder.jobFunction = null;
+        // Issue#66: remove 2 stakeholder groups
+        stakeholder.stakeholderGroups = Set.of(managers);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .pathParam("id", stakeholder.id)
+                .body(stakeholder)
+                .when()
+                .put("/stakeholder/{id}")
+                .then()
+                .statusCode(is(204));
+
+        // check the stakeholder has NO job function in the response
+        given()
+                .accept("application/hal+json")
+                .queryParam("displayName", stakeholderDisplayName)
+                .body(stakeholder)
+                .when()
+                .get("/stakeholder")
+                .then()
+                .statusCode(is(200))
+                .body("_embedded.stakeholder[0].jobFunction.role", is(emptyOrNullString()),
+                        "_embedded.stakeholder[0].stakeholderGroups.size()", is(1),
+                        "_embedded.stakeholder[0].stakeholderGroups.size()", is(1),
+                        "_embedded.stakeholder[0].stakeholderGroups[0].name", is("Managers"));
+
+        // delete the resource created in this test to not interfere with other tests
+        given()
+                .pathParam("id", chef.id)
+                .when()
+                .delete("/job-function/{id}")
+                .then()
+                .statusCode(204);
+
+        given()
+                .pathParam("id", stakeholder.id)
+                .when()
+                .delete("/stakeholder/{id}")
+                .then()
+                .statusCode(204);
+
+        given()
+                .pathParam("id", businessService.id)
+                .when()
+                .delete("/business-service/{id}")
+                .then()
+                .statusCode(204);
+    }
+}


### PR DESCRIPTION
resolve #64 
resolve #66 

The test reproducer:
1. creates new job function (`chef`)
1. uses three already existing stakeholder groups
1. creates new stakeholder referencing entities above
1. creates a new business service with stakeholder as owner
1. removes the owner from the business service
1. (from the issue) removes the job function
1. (from the issue) removes 2 (out of 3) stakeholder groups from stakeholder
1. checks the stakeholder is in the expected state
1. deletes job function, stakeholder and business service to not alter other tests

Fix:
* created a dedicated resource for handling the `PUT` verb for `Stakeholder` resource for *ONLY* updating resources (not creating)
* implemented `equals(Object o)` and `hashCode()` methods for both `Stakeholder` and `StakeholderGroup` to have `remove` and `contains` methods to work properly
* disabled update methods creation from Panache in `StakeholderResource`