### PR TITLE
Upgrade to Quarkus 2.5.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>io.tackle</groupId>
+      <groupId>com.github.konveyor.tackle-commons-rest</groupId>
       <artifactId>commons-rest</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>0.0.2</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -113,9 +113,9 @@
       <artifactId>quarkus-keycloak-authorization</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.tackle</groupId>
+      <groupId>com.github.konveyor.tackle-commons-rest</groupId>
       <artifactId>commons-rest-test</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
+      <version>0.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,14 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.platform.version>1.12.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.5.4.Final</quarkus.platform.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
 <!--    <quarkus.platform.version>999-SNAPSHOT</quarkus.platform.version>-->
 <!--    <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>-->
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus-plugin.version>1.12.2.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.5.4.Final</quarkus-plugin.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
-    <testcontainers.version>1.15.2</testcontainers.version>
+    <testcontainers.version>1.16.0</testcontainers.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
     <jacoco.version>0.8.7</jacoco.version>
     <quarkus.package.type>jar</quarkus.package.type>
@@ -51,9 +51,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.konveyor.tackle-commons-rest</groupId>
+      <groupId>io.tackle</groupId>
       <artifactId>commons-rest</artifactId>
-      <version>0.0.1</version>
+      <version>0.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -70,6 +70,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-links</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -109,9 +113,9 @@
       <artifactId>quarkus-keycloak-authorization</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.github.konveyor.tackle-commons-rest</groupId>
+      <groupId>io.tackle</groupId>
       <artifactId>commons-rest-test</artifactId>
-      <version>0.0.1</version>
+      <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -235,7 +239,7 @@
       <properties>
         <quarkus.native.container-build>true</quarkus.native.container-build>
         <quarkus.package.type>native</quarkus.package.type>
-        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:20.3-java11</quarkus.native.builder-image>
+        <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
       </properties>
     </profile>
     <profile>

--- a/src/main/java/io/tackle/controls/resources/StakeholderAddResource.java
+++ b/src/main/java/io/tackle/controls/resources/StakeholderAddResource.java
@@ -1,0 +1,42 @@
+package io.tackle.controls.resources;
+
+import io.tackle.controls.entities.Stakeholder;
+import org.hibernate.exception.ConstraintViolationException;
+import org.jboss.resteasy.links.LinkResource;
+
+import javax.persistence.PersistenceException;
+import javax.transaction.Transactional;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.*;
+
+@Path("stakeholder")
+public class StakeholderAddResource {
+
+    @Path("/")
+    @Transactional
+    @POST
+    @Consumes({"application/json"})
+    @Produces({"application/json", "application/hal+json"})
+    @LinkResource(
+            entityClassName = "io.tackle.controls.entities.Stakeholder",
+            rel = "add"
+    )
+    public Response add(Stakeholder stakeholder) {
+        try {
+            stakeholder.persistAndFlush();
+        } catch (PersistenceException e) {
+            if (e.getCause() instanceof ConstraintViolationException) {
+                return Response.status(CONFLICT).build();
+            } else {
+                throw e;
+            }
+        }
+
+        return Response.status(CREATED).entity(stakeholder).build();
+    }
+}

--- a/src/main/java/io/tackle/controls/resources/StakeholderResource.java
+++ b/src/main/java/io/tackle/controls/resources/StakeholderResource.java
@@ -15,5 +15,8 @@ public interface StakeholderResource extends PanacheEntityResource<Stakeholder, 
     List<Stakeholder> list(Page page, Sort sort);
 
     @MethodProperties(exposed = false)
+    Stakeholder add(Stakeholder stakeholder);
+
+    @MethodProperties(exposed = false)
     Stakeholder update(Long id, Stakeholder stakeholder);
 }

--- a/src/test/java/io/tackle/controls/resources/StakeholderTest.java
+++ b/src/test/java/io/tackle/controls/resources/StakeholderTest.java
@@ -202,14 +202,26 @@ public class StakeholderTest extends SecuredResourceTest {
         stakeholder.stakeholderGroups.add(stakeholderGroup);
         stakeholder.stakeholderGroups.add(nonexistent);
 
-        Response response = given()
+        Long stakeholderId = Long.valueOf(
+                given()
                 .contentType(ContentType.JSON)
                 .accept("application/hal+json")
                 .body(stakeholder)
                 .when().log().body().post(PATH)
                 .then()
                 .log().all()
-                .statusCode(201).extract().response();
+                .statusCode(201)
+                .extract().path("id").toString()
+        );
+
+        Response response = given()
+                .accept("application/hal+json")
+                .pathParam("id", stakeholderId)
+                .when()
+                .get(PATH + "/{id}")
+                .then()
+                .statusCode(200)
+                .extract().response();
 
         assertEquals(displayName, response.path("displayName"));
         assertEquals(email, response.path("email"));
@@ -217,7 +229,7 @@ public class StakeholderTest extends SecuredResourceTest {
         assertEquals("alice", response.path("createUser"));
         assertEquals("alice", response.path("updateUser"));
 
-        Long stakeholderId = Long.valueOf(response.path("id").toString());
+        stakeholderId = Long.valueOf(response.path("id").toString());
 
         StakeholderGroup sg = new StakeholderGroup();
         sg.id = 54L;


### PR DESCRIPTION
Depends on https://github.com/konveyor/tackle-commons-rest/pull/119

https://github.com/konveyor/tackle-commons-rest/pull/119 needs to be merged and a new version/tag must be released so it can be used within the pom.xml file; without a new release of https://github.com/konveyor/tackle-commons-rest this PR won't pass the tests.

## How to generate a container image based on this PR?
After checking out this PR you can execute the following command:

```
mvn -U -B package --file pom.xml \
  -Pcontainer-image -Pnative -DskipTests \
  -Dquarkus.container-image.push=true \
  -Dquarkus.container-image.group=YOUR_QUAY_USERNAME \
  -Dquarkus.container-image.additional-tags=quarkus2 \
  -Dquarkus.container-image.registry=quay.io \
  -Dquarkus.container-image.username=YOUR_QUAY_ROBOT_USERNAME \
  -Dquarkus.container-image.password=YOUR_QUAY_ROBOT_TOKEN
```

It will generate a new container image named `quay.io/YOUR_QUAY_USERNAME/tackle-controls:quarkus2` which should be used on any K8s environment you might have.

## How to deploy the container image using Minukube
Start Minikube using:
```
minikube start && minikube addons enable metrics-server && minikube addons enable ingress
```

Create a namespace:
```
kubectl create namespace tackle
```

Init the K8s resources: for this you can download this file https://github.com/konveyor/tackle/blob/main/kubernetes/kubernetes-tackle.yaml and manually edit the following lines:
- https://github.com/konveyor/tackle/blob/main/kubernetes/kubernetes-tackle.yaml#L2646
- https://github.com/konveyor/tackle/blob/main/kubernetes/kubernetes-tackle.yaml#L2726
- https://github.com/konveyor/tackle/blob/main/kubernetes/kubernetes-tackle.yaml#L2806

Make sure the previous lines point to your own container images; then finally create all resources using:
```
kubectl apply -f directoryWhereYouDownloadedFile/kubernetes-tackle.yaml -n tackle
```

## See Tackle running
After you deployed Tackle into Minikube following the previous steps you can see the current progress of the deployments using:

```
minikube dashboard
```

And then select the namespace `tackle`. Once all Deployments finish you can go to the left sidebar menu `Ingresses` and enter to the URL that should take you to the Tackle UI webpage.

## What else to verify
Since  you enabled the addon metrics-server you should be able to see the following metrics:

![Screenshot from 2021-12-15 11-43-32](https://user-images.githubusercontent.com/2582866/148204904-37b80aa3-5f1c-4207-a1f3-26291db1c5d5.png)

Make sure the values of memory for each Tackle backend don't go over 100MB which was the results I've found in my laptop.