### PR TITLE
[TACKLE-355]: [Tackle - 1.2 - regression] Control entities name unique constraint validation

### DIFF
--- a/src/main/java/io/tackle/controls/exceptions/CustomRestDataPanacheExceptionMapper.java
+++ b/src/main/java/io/tackle/controls/exceptions/CustomRestDataPanacheExceptionMapper.java
@@ -1,0 +1,50 @@
+package io.tackle.controls.exceptions;
+
+import io.quarkus.arc.ArcUndeclaredThrowableException;
+import io.quarkus.hibernate.orm.rest.data.panache.runtime.RestDataPanacheExceptionMapper;
+import io.quarkus.rest.data.panache.RestDataPanacheException;
+import org.jboss.logging.Logger;
+
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This ExceptionMapper is based on RestDataPanacheExceptionMapper. The purpose is to have a custom formatted
+ * response {"errorMessage": "the error message"} rather than a generic one.
+ */
+@Priority(1)
+@Provider
+public class CustomRestDataPanacheExceptionMapper implements ExceptionMapper<RestDataPanacheException> {
+
+    private static final Logger LOGGER = Logger.getLogger(RestDataPanacheExceptionMapper.class);
+
+    @Override
+    public Response toResponse(RestDataPanacheException exception) {
+        LOGGER.warnf(exception, "Mapping an unhandled %s", RestDataPanacheException.class.getSimpleName());
+        return throwableToResponse(exception, exception.getMessage());
+    }
+
+    private Response throwableToResponse(Throwable throwable, String message) {
+        if (throwable instanceof ArcUndeclaredThrowableException) {
+            ArcUndeclaredThrowableException e = (ArcUndeclaredThrowableException) throwable;
+            return new ArcUndeclaredThrowableExceptionMapper().toResponse(e);
+        }
+
+        if (throwable instanceof org.hibernate.exception.ConstraintViolationException) {
+            return Response.status(Response.Status.CONFLICT.getStatusCode(), message).build();
+        }
+
+        if (throwable instanceof javax.validation.ConstraintViolationException) {
+            return Response.status(Response.Status.BAD_REQUEST.getStatusCode(), message).build();
+        }
+
+        if (throwable.getCause() != null) {
+            return throwableToResponse(throwable.getCause(), message);
+        }
+
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), message).build();
+    }
+
+}

--- a/src/main/java/io/tackle/controls/resources/StakeholderAddResource.java
+++ b/src/main/java/io/tackle/controls/resources/StakeholderAddResource.java
@@ -1,7 +1,7 @@
 package io.tackle.controls.resources;
 
+import io.quarkus.arc.ArcUndeclaredThrowableException;
 import io.tackle.controls.entities.Stakeholder;
-import org.hibernate.exception.ConstraintViolationException;
 import org.jboss.resteasy.links.LinkResource;
 
 import javax.persistence.PersistenceException;
@@ -12,7 +12,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.CREATED;
 
 @Path("stakeholder")
 public class StakeholderAddResource {
@@ -30,11 +30,7 @@ public class StakeholderAddResource {
         try {
             stakeholder.persistAndFlush();
         } catch (PersistenceException e) {
-            if (e.getCause() instanceof ConstraintViolationException) {
-                return Response.status(CONFLICT).build();
-            } else {
-                throw e;
-            }
+            throw new ArcUndeclaredThrowableException("Error while persisting stakeholder", e);
         }
 
         return Response.status(CREATED).entity(stakeholder).build();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,7 +24,7 @@ quarkus.hibernate-orm.log.bind-parameters=true
 %dev.quarkus.log.category."org.hibernate.type.descriptor.sql.BasicBinder".level=FINER
 
 # use 'update' to generate SQL scripts, validate them and then create a new file into resources/db/migration folder
-%dev.quarkus.hibernate-orm.database.generation = drop-and-create
+%dev.quarkus.hibernate-orm.database.generation = validate
 %dev.quarkus.hibernate-orm.sql-load-script = import-dev.sql
 %test.quarkus.hibernate-orm.database.generation = validate
 # DO NOT REMOVE/CHANGE. Make sure to not drop our database in production!
@@ -34,7 +34,7 @@ quarkus.hibernate-orm.log.bind-parameters=true
 
 # flyway configuration
 quarkus.flyway.migrate-at-start=true
-%dev.quarkus.flyway.migrate-at-start=false
+%dev.quarkus.flyway.migrate-at-start=true
 %test.quarkus.flyway.locations=db/migration,db/test-data
 %minikube.quarkus.flyway.locations=db/migration,db/test-data
 

--- a/src/test/java/io/tackle/controls/resources/ServicesParameterizedTest.java
+++ b/src/test/java/io/tackle/controls/resources/ServicesParameterizedTest.java
@@ -148,7 +148,8 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
                 .post(resource)
                 .then()
                 // this will expect the same '409' from Quarkus 1.13+ with the introduction of RestDataPanacheException
-                .statusCode(409);
+                .statusCode(409)
+                .body("errorMessage", is("ERROR: duplicate key value violates unique constraint"));
 
         // remove the initial entity
         given()


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-355

- Added custom `CustomRestDataPanacheExceptionMapper` to override the default Mapper coming from Quarkus.
- Enhanced the `ServicesParameterizedTest.java` to verify the DB duplicate error message is the expected one

I've locally created a container image based on this PR `quay.io/carlosthe19916/tackle-controls:TACKLE-355` and you can use it to test it if required. Although you can always create your own container image executing:

```
mvn -U -B package --file pom.xml -Pcontainer-image -Pnative -DskipTests \
  -Dquarkus.container-image.push=true \
  -Dquarkus.container-image.group=YOUR_QUAY_USERNAME \
  -Dquarkus.container-image.additional-tags=TACKLE-355 \
  -Dquarkus.container-image.registry=quay.io \
  -Dquarkus.container-image.username=YOUR_QUAY_USERNAME \
  -Dquarkus.container-image.password=YOUR_QUAY_PASSWORD
```